### PR TITLE
[ROS-O] Modernize CI / cmake

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,12 +11,9 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - IMAGE: melodic
-            CCOV: true
-            CATKIN_LINT: true
-            UPSTREAM_WORKSPACE: github:PickNikRobotics/rviz_visual_tools#master
           - IMAGE: noetic
             CATKIN_LINT: true
+            CCOV: true
     env:
       DOCKER_IMAGE: 'moveit/moveit:${{ matrix.env.IMAGE }}-release'
       AFTER_RUN_TARGET_TEST: ${{ matrix.env.CCOV && './.ci.prepare_codecov' || '' }}
@@ -31,33 +28,35 @@ jobs:
     name: "${{ matrix.env.IMAGE }}${{ matrix.env.CATKIN_LINT && ' + catkin_lint' || ''}}${{ matrix.env.CCOV && ' + ccov' || ''}}${{ matrix.env.IKFAST_TEST && ' + ikfast' || ''}}${{ matrix.env.CLANG_TIDY && ' + clang-tidy' || '' }}"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: cache upstream_ws
-        uses: pat-s/always-upload-cache@v2.1.3
+        uses: actions/cache@v4
         with:
+          save-always: true
           path: ${{ env.BASEDIR }}/upstream_ws
           key: upstream_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('upstream.rosinstall') }}-${{ github.run_id }}
           restore-keys: |
             upstream_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('upstream.rosinstall') }}
       - name: cache ccache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
+          save-always: true
           path: ${{ env.CCACHE_DIR }}
           key: ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
             ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}
             ccache-${{ env.CACHE_PREFIX }}
       - name: industrial_ci
-        uses: 'ros-industrial/industrial_ci@master'
+        uses: ros-industrial/industrial_ci@master
         env: ${{ matrix.env }}
       - name: upload test artifacts (on failure)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: test-results
           path: ${{ env.BASEDIR }}/target_ws/**/test_results/**/*.xml
       - name: upload codecov report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4
         if: ${{ matrix.env.CCOV }}
         with:
           files: ${{ env.BASEDIR }}/coverage.info

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -11,21 +11,10 @@ on:
 jobs:
   pre-commit:
     name: pre-commit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
       - name: Install clang-format-10
         run: sudo apt-get install clang-format-10
-      - name: Install catkin-lint
-        run: |
-          lsb_release -sc
-          sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
-          sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
-          sudo apt-get -q update
-          sudo apt-get -q install python3-rosdep
-          sudo rosdep init
-          rosdep update
-          sudo apt-get -q install catkin-lint
-          export ROS_DISTRO=noetic
-      - uses: pre-commit/action@v2.0.0
+      - uses: rhaschke/install-catkin_lint-action@v1.0
+      - uses: pre-commit/action@v3.0.1

--- a/moveit_calibration_gui/CMakeLists.txt
+++ b/moveit_calibration_gui/CMakeLists.txt
@@ -1,13 +1,6 @@
 cmake_minimum_required(VERSION 3.1.3)
 project(moveit_calibration_gui)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
-if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
-endif()
-
 find_package(catkin REQUIRED COMPONENTS
   class_loader
   cv_bridge
@@ -29,6 +22,8 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(Eigen3 REQUIRED)
+
+moveit_build_options()
 
 # Qt Stuff
 if(rviz_QT_VERSION VERSION_LESS "5")

--- a/moveit_calibration_plugins/CMakeLists.txt
+++ b/moveit_calibration_plugins/CMakeLists.txt
@@ -1,13 +1,6 @@
 cmake_minimum_required(VERSION 3.1.3)
 project(moveit_calibration_plugins)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
-if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
-endif()
-
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   rosconsole
@@ -20,6 +13,9 @@ find_package(catkin REQUIRED COMPONENTS
 
 find_package(Eigen3 REQUIRED)
 find_package(OpenCV REQUIRED imgcodecs aruco)
+find_package(moveit_core REQUIRED)
+
+moveit_build_options()
 
 if(OpenCV_VERSION VERSION_EQUAL 3.2)
   message(WARNING "Your version of OpenCV (3.2) is known to have buggy ArUco pose detection! Use a ChArUco target or upgrade OpenCV")

--- a/moveit_calibration_plugins/package.xml
+++ b/moveit_calibration_plugins/package.xml
@@ -14,6 +14,7 @@
   <url type="repository">https://github.com/ros-planning/moveit_calibration</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>moveit_core</build_depend>
 
   <depend>roscpp</depend>
   <depend>rosconsole</depend>


### PR DESCRIPTION
- Replace enforcement of (old) C++14 standard with moveit_build_options()
  Ubuntu 22.04 uses C++17 as default and fails on old C++14
- Modernize CI setup